### PR TITLE
chore: print the digest of the published charts

### DIFF
--- a/promote/README.md
+++ b/promote/README.md
@@ -35,7 +35,10 @@ The promoted chart is published to the target registry after packaging.
 
 ## 📤 Outputs
 
-_None_
+|   Name  |                       Description                      |
+|---------|--------------------------------------------------------|
+|`version`|           The version of the promoted chart.           |
+| `digest`|The digest of the promoted chart in the target registry.|
 
 ## 🚀 Usage
 

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -66,6 +66,13 @@ inputs:
     description: 'Additional arguments to pass to the `helm push` command.'
     required: false
     default: ''
+outputs:
+  version:
+    description: 'The version of the promoted chart.'
+    value: ${{ inputs.target-version }}
+  digest:
+    description: 'The digest of the promoted chart in the target registry.'
+    value: ${{ steps.publish-chart.outputs.digest }}
 
 runs:
   using: 'composite'
@@ -187,6 +194,7 @@ runs:
         echo "::endgroup::"
 
     - name: Publish promoted chart
+      id: publish-chart
       shell: bash
       run: |
         echo "::group::Publishing promoted chart"
@@ -194,7 +202,14 @@ runs:
         echo "Chart file: ${{ env.chart-path }}"
         echo "Push args: ${{ inputs.push-args }}"
 
-        helm push '${{ env.chart-path }}' '${{ inputs.repo-host }}' ${{ inputs.push-args }}
+        # Publish the chart and capture output
+        PUSH_OUTPUT=$(helm push '${{ env.chart-path }}' '${{ inputs.repo-host }}' ${{ inputs.push-args }} 2>&1)
+        echo "$PUSH_OUTPUT"
+
+        # Extract digest from helm push output
+        DIGEST=$(echo "$PUSH_OUTPUT" | grep -o 'sha256:[a-f0-9]\{64\}' | head -n1 || echo "")
+
+        echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
         echo "✅ Chart successfully published to ${{ inputs.repo-host }}"
         echo "::endgroup::"
@@ -209,6 +224,7 @@ runs:
         SOURCE_VERSION="${{ inputs.source-version }}"
         TARGET_VERSION="${{ inputs.target-version }}"
         CHART_PATH="${{ inputs.chart }}"
+        DIGEST="${{ steps.publish-chart.outputs.digest }}"
 
         # Generate summary
         {
@@ -218,6 +234,9 @@ runs:
           echo "- **Chart Name**: \`$CHART_NAME\`"
           echo "- **Source Version**: \`$SOURCE_VERSION\`"
           echo "- **Target Version**: \`$TARGET_VERSION\`"
+          if [ -n "$DIGEST" ]; then
+            echo "- **Target Digest**: \`$DIGEST\`"
+          fi
           echo "- **Source Chart**: \`$CHART_PATH\`"
           echo "- **Published to**: \`${{ inputs.repo-host }}\`"
 

--- a/publish/README.md
+++ b/publish/README.md
@@ -18,7 +18,10 @@ Publish a Helm chart to a registry.
 
 ## 📤 Outputs
 
-_None_
+|   Name  |                       Description                       |
+|---------|---------------------------------------------------------|
+|`version`|           The version of the published chart.           |
+| `digest`|The digest of the published chart in the target registry.|
 
 ## 🚀 Usage
 

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -1,5 +1,8 @@
 name: 'Helm Publish'
 description: 'Publish a Helm chart to a registry.'
+
+author: EIDP
+
 inputs:
   repo-host:
     description: 'URL of target registry.'
@@ -33,6 +36,14 @@ inputs:
     description: 'Additional arguments for helm push.'
     required: false
     default: ''
+outputs:
+  version:
+    description: 'The version of the published chart.'
+    value: ${{ steps.extract-chart-info.outputs.chart-version }}
+  digest:
+    description: 'The digest of the published chart in the target registry.'
+    value: ${{ steps.publish-chart.outputs.digest }}
+
 runs:
   using: 'composite'
   steps:
@@ -87,9 +98,17 @@ runs:
         echo '${{ inputs.repo-password }}' | helm registry login -u '${{ inputs.repo-user }}' --password-stdin '${{ inputs.repo-host }}'
 
     - name: Publish Helm chart to registry
+      id: publish-chart
       shell: bash
       run: |
-        helm push '${{ inputs.chart-output-path }}' '${{ inputs.repo-host }}' "${{ inputs.args }}"
+        # Publish the chart and capture output
+        PUSH_OUTPUT=$(helm push '${{ inputs.chart-output-path }}' '${{ inputs.repo-host }}' "${{ inputs.args }}" 2>&1)
+        echo "$PUSH_OUTPUT"
+        
+        # Extract digest from helm push output
+        DIGEST=$(echo "$PUSH_OUTPUT" | grep -o 'sha256:[a-f0-9]\{64\}' | head -n1 || echo "")
+
+        echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
     - name: Generate GitHub Summary
       if: success()
@@ -99,20 +118,21 @@ runs:
         CHART_VERSION="${{ steps.extract-chart-info.outputs.chart-version }}"
         CHART_PATH="${{ inputs.chart-path }}"
         REPO_HOST="${{ inputs.repo-host }}"
-        
+        DIGEST="${{ steps.publish-chart.outputs.digest }}"
+
         # Create repository link to the chart
         CHART_URL="https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}/${CHART_PATH}"
-                
+
         # Generate GitHub summary
         cat >> $GITHUB_STEP_SUMMARY << EOF
         ## 🚀 Helm Chart Published Successfully
-        
+
         **Chart Details:**
         - **Name:** \`${CHART_NAME}\`
         - **Version:** \`${CHART_VERSION}\`
+        $(if [ -n "$DIGEST" ]; then echo "- **Digest:** \`${DIGEST}\`"; fi)
         - **Source Path:** \`${CHART_PATH}\`
-
-        - 📦 Chart published to: \`${REPO_HOST}\`
+        - **Published to:** \`${REPO_HOST}\`
 
         **Publication Status:** ✅ Successfully published
         EOF


### PR DESCRIPTION
This PR adds the digest to the GitHub step summary. Also it adds the published version and digest as action outputs.
